### PR TITLE
feat: PvsSearchEngine への Transposition Table 統合 (Task 3b)

### DIFF
--- a/Reluca.Tests/Search/PvsSearchEngineUnitTest.cs
+++ b/Reluca.Tests/Search/PvsSearchEngineUnitTest.cs
@@ -5,8 +5,8 @@
 /// 副作用: なし
 ///
 /// テスト方針:
-/// - LegacySearchEngine と同一局面・同一深さで BestMove / Value が一致すること
-/// - これにより PVS 実装の正しさを保証する
+/// - TT OFF で有効な手が返ることを確認
+/// - DI 経由での解決が正しく動作すること
 /// </summary>
 using Reluca.Accessors;
 using Reluca.Contexts;
@@ -31,17 +31,12 @@ namespace Reluca.Tests.Search
         private PvsSearchEngine Target { get; set; }
 
         /// <summary>
-        /// 比較用の LegacySearchEngine
-        /// </summary>
-        private LegacySearchEngine LegacyEngine { get; set; }
-
-        /// <summary>
         /// コンストラクタ
         /// </summary>
         public PvsSearchEngineUnitTest()
         {
-            Target = new PvsSearchEngine();
-            LegacyEngine = new LegacySearchEngine();
+            // DI 経由でインスタンスを取得
+            Target = DiProvider.Get().GetService<PvsSearchEngine>();
         }
 
         /// <summary>
@@ -58,8 +53,6 @@ namespace Reluca.Tests.Search
 
         /// <summary>
         /// 初期局面で探索が正常に動作し、有効な手を返す
-        /// 注: Cacher の状態汚染によりテスト順序で結果が変わる問題があるため、
-        ///     PvsSearchEngine 単体での動作確認を行う
         /// </summary>
         [TestMethod]
         public void 初期局面で探索が正常に動作する()
@@ -102,8 +95,6 @@ namespace Reluca.Tests.Search
 
         /// <summary>
         /// 終盤局面（DiscCountEvaluator）で探索が正常に動作する
-        /// 注: LegacySearchEngine との比較はテスト順序によるCacher汚染問題があるため、
-        ///     PvsSearchEngine 単体での動作確認のみ行う
         /// </summary>
         [TestMethod]
         public void 終盤局面で探索が正常に動作する()

--- a/Reluca.Tests/Search/PvsSearchEngineWithTTUnitTest.cs
+++ b/Reluca.Tests/Search/PvsSearchEngineWithTTUnitTest.cs
@@ -1,0 +1,186 @@
+/// <summary>
+/// 【ModuleDoc】
+/// 責務: PvsSearchEngine の Transposition Table 統合テストを提供する
+/// 入出力: テストケース → テスト結果
+/// 副作用: なし
+///
+/// テスト方針:
+/// - TT OFF で有効な手が返ることを確認
+/// - TT ON で有効な手が返ることを確認
+/// - TT ON/OFF で同一結果が返ることを確認
+/// </summary>
+using Reluca.Accessors;
+using Reluca.Contexts;
+using Reluca.Converters;
+using Reluca.Di;
+using Reluca.Evaluates;
+using Reluca.Helpers;
+using Reluca.Search;
+
+namespace Reluca.Tests.Search
+{
+#pragma warning disable CS8602 // null 参照の可能性があるものの逆参照です。
+    /// <summary>
+    /// PvsSearchEngine の Transposition Table 統合テストクラスです。
+    /// </summary>
+    [TestClass]
+    public class PvsSearchEngineWithTTUnitTest
+    {
+        /// <summary>
+        /// リソースファイルからゲーム状態を作成します。
+        /// </summary>
+        /// <param name="index">インデックス</param>
+        /// <param name="childIndex">子インデックス</param>
+        /// <param name="type">リソース種別</param>
+        /// <returns>ゲーム状態</returns>
+        private GameContext CreateGameContext(int index, int childIndex, ResourceType type)
+        {
+            return UnitTestHelper.CreateGameContext("LegacySearchEngine", index, childIndex, type);
+        }
+
+        /// <summary>
+        /// TT OFF で探索が正常に動作する
+        /// </summary>
+        [TestMethod]
+        public void TT_OFFで探索が正常に動作する()
+        {
+            // Arrange
+            var target = DiProvider.Get().GetService<PvsSearchEngine>();
+            var context = CreateGameContext(1, 1, ResourceType.In);
+            var evaluator = DiProvider.Get().GetService<FeaturePatternEvaluator>();
+            var options = new SearchOptions(7, useTranspositionTable: false);
+
+            // Act
+            var result = target.Search(context, options, evaluator);
+
+            // Assert
+            var validMoves = new[] { 19, 26, 37, 44 }; // d3, c4, f5, e6
+            Assert.IsTrue(validMoves.Contains(result.BestMove),
+                $"TT OFF: 無効な手が返されました: {BoardAccessor.ToPosition(result.BestMove)}");
+        }
+
+        /// <summary>
+        /// TT ON で探索が正常に動作する
+        /// </summary>
+        [TestMethod]
+        public void TT_ONで探索が正常に動作する()
+        {
+            // Arrange
+            var target = DiProvider.Get().GetService<PvsSearchEngine>();
+            var context = CreateGameContext(1, 1, ResourceType.In);
+            var evaluator = DiProvider.Get().GetService<FeaturePatternEvaluator>();
+            var options = new SearchOptions(7, useTranspositionTable: true);
+
+            // Act
+            var result = target.Search(context, options, evaluator);
+
+            // Assert
+            var validMoves = new[] { 19, 26, 37, 44 }; // d3, c4, f5, e6
+            Assert.IsTrue(validMoves.Contains(result.BestMove),
+                $"TT ON: 無効な手が返されました: {BoardAccessor.ToPosition(result.BestMove)}");
+        }
+
+        /// <summary>
+        /// TT ON と OFF で同一の BestMove を返す（初期局面）
+        /// </summary>
+        [TestMethod]
+        public void TT_ON_OFFで同一の結果を返す_初期局面()
+        {
+            // Arrange
+            var context = CreateGameContext(1, 1, ResourceType.In);
+            var evaluator = DiProvider.Get().GetService<FeaturePatternEvaluator>();
+
+            // Act: TT OFF
+            var targetOff = DiProvider.Get().GetService<PvsSearchEngine>();
+            var optionsOff = new SearchOptions(7, useTranspositionTable: false);
+            var resultOff = targetOff.Search(context, optionsOff, evaluator);
+
+            // Act: TT ON（新しいインスタンスを使用）
+            var contextOn = CreateGameContext(1, 1, ResourceType.In);
+            var targetOn = DiProvider.Get().GetService<PvsSearchEngine>();
+            var optionsOn = new SearchOptions(7, useTranspositionTable: true);
+            var resultOn = targetOn.Search(contextOn, optionsOn, evaluator);
+
+            // Assert
+            Console.WriteLine($"TT OFF: BestMove={BoardAccessor.ToPosition(resultOff.BestMove)}, Value={resultOff.Value}");
+            Console.WriteLine($"TT ON:  BestMove={BoardAccessor.ToPosition(resultOn.BestMove)}, Value={resultOn.Value}");
+
+            Assert.AreEqual(resultOff.BestMove, resultOn.BestMove,
+                $"BestMove が一致しません: OFF={BoardAccessor.ToPosition(resultOff.BestMove)}, ON={BoardAccessor.ToPosition(resultOn.BestMove)}");
+            Assert.AreEqual(resultOff.Value, resultOn.Value,
+                $"Value が一致しません: OFF={resultOff.Value}, ON={resultOn.Value}");
+        }
+
+        /// <summary>
+        /// TT ON と OFF で同一の BestMove を返す（中盤局面）
+        /// </summary>
+        [TestMethod]
+        public void TT_ON_OFFで同一の結果を返す_中盤局面()
+        {
+            // Arrange
+            var context = CreateGameContext(2, 1, ResourceType.In);
+            var evaluator = DiProvider.Get().GetService<FeaturePatternEvaluator>();
+
+            // Act: TT OFF
+            var targetOff = DiProvider.Get().GetService<PvsSearchEngine>();
+            var optionsOff = new SearchOptions(7, useTranspositionTable: false);
+            var resultOff = targetOff.Search(context, optionsOff, evaluator);
+
+            // Act: TT ON（新しいインスタンスを使用）
+            var contextOn = CreateGameContext(2, 1, ResourceType.In);
+            var targetOn = DiProvider.Get().GetService<PvsSearchEngine>();
+            var optionsOn = new SearchOptions(7, useTranspositionTable: true);
+            var resultOn = targetOn.Search(contextOn, optionsOn, evaluator);
+
+            // Assert
+            Console.WriteLine($"TT OFF: BestMove={BoardAccessor.ToPosition(resultOff.BestMove)}, Value={resultOff.Value}");
+            Console.WriteLine($"TT ON:  BestMove={BoardAccessor.ToPosition(resultOn.BestMove)}, Value={resultOn.Value}");
+
+            Assert.AreEqual(resultOff.BestMove, resultOn.BestMove,
+                $"BestMove が一致しません: OFF={BoardAccessor.ToPosition(resultOff.BestMove)}, ON={BoardAccessor.ToPosition(resultOn.BestMove)}");
+            Assert.AreEqual(resultOff.Value, resultOn.Value,
+                $"Value が一致しません: OFF={resultOff.Value}, ON={resultOn.Value}");
+        }
+
+        /// <summary>
+        /// TT ON で深さ 5 の探索が正常に動作する
+        /// </summary>
+        [TestMethod]
+        public void TT_ONで深さ5の探索が正常に動作する()
+        {
+            // Arrange
+            var target = DiProvider.Get().GetService<PvsSearchEngine>();
+            var context = CreateGameContext(1, 1, ResourceType.In);
+            var evaluator = DiProvider.Get().GetService<FeaturePatternEvaluator>();
+            var options = new SearchOptions(5, useTranspositionTable: true);
+
+            // Act
+            var result = target.Search(context, options, evaluator);
+
+            // Assert
+            Assert.IsTrue(result.BestMove >= 0 && result.BestMove < 64,
+                $"無効な手が返されました: {result.BestMove}");
+        }
+
+        /// <summary>
+        /// TT ON で終盤局面の探索が正常に動作する
+        /// </summary>
+        [TestMethod]
+        public void TT_ONで終盤局面の探索が正常に動作する()
+        {
+            // Arrange
+            var target = DiProvider.Get().GetService<PvsSearchEngine>();
+            var context = CreateGameContext(1, 1, ResourceType.In);
+            context.TurnCount = 50;
+            var evaluator = DiProvider.Get().GetService<DiscCountEvaluator>();
+            var options = new SearchOptions(5, useTranspositionTable: true);
+
+            // Act
+            var result = target.Search(context, options, evaluator);
+
+            // Assert
+            Assert.IsTrue(result.BestMove >= 0 && result.BestMove < 64,
+                $"無効な手が返されました: {result.BestMove}");
+        }
+    }
+}

--- a/Reluca.Tests/Search/Transposition/ZobristHashUnitTest.cs
+++ b/Reluca.Tests/Search/Transposition/ZobristHashUnitTest.cs
@@ -17,6 +17,19 @@ namespace Reluca.Tests.Search.Transposition
     public class ZobristHashUnitTest
     {
         /// <summary>
+        /// テスト対象のインスタンス
+        /// </summary>
+        private readonly IZobristHash _zobristHash;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        public ZobristHashUnitTest()
+        {
+            _zobristHash = new ZobristHash();
+        }
+
+        /// <summary>
         /// 同一盤面は同一ハッシュを返す
         /// </summary>
         [TestMethod]
@@ -27,8 +40,8 @@ namespace Reluca.Tests.Search.Transposition
             var context2 = CreateInitialPosition();
 
             // Act
-            var hash1 = ZobristHash.ComputeHash(context1);
-            var hash2 = ZobristHash.ComputeHash(context2);
+            var hash1 = _zobristHash.ComputeHash(context1);
+            var hash2 = _zobristHash.ComputeHash(context2);
 
             // Assert
             Assert.AreEqual(hash1, hash2, "同一盤面のハッシュが異なります");
@@ -42,7 +55,7 @@ namespace Reluca.Tests.Search.Transposition
         {
             // Arrange: 初期局面
             var context1 = CreateInitialPosition();
-            var hash1 = ZobristHash.ComputeHash(context1);
+            var hash1 = _zobristHash.ComputeHash(context1);
 
             // 1手進めた局面（d3に黒石を置き、d4を裏返す）
             var context2 = CreateInitialPosition();
@@ -52,7 +65,7 @@ namespace Reluca.Tests.Search.Transposition
             context2.Turn = Disc.Color.White; // 白番に
 
             // Act
-            var hash2 = ZobristHash.ComputeHash(context2);
+            var hash2 = _zobristHash.ComputeHash(context2);
 
             // Assert
             Assert.AreNotEqual(hash1, hash2, "1手進めた盤面のハッシュが同じです");
@@ -72,8 +85,8 @@ namespace Reluca.Tests.Search.Transposition
             contextWhite.Turn = Disc.Color.White;
 
             // Act
-            var hashBlack = ZobristHash.ComputeHash(contextBlack);
-            var hashWhite = ZobristHash.ComputeHash(contextWhite);
+            var hashBlack = _zobristHash.ComputeHash(contextBlack);
+            var hashWhite = _zobristHash.ComputeHash(contextWhite);
 
             // Assert
             Assert.AreNotEqual(hashBlack, hashWhite, "手番が異なる盤面のハッシュが同じです");
@@ -97,14 +110,14 @@ namespace Reluca.Tests.Search.Transposition
             };
 
             // Act
-            var hash = ZobristHash.ComputeHash(context);
+            var hash = _zobristHash.ComputeHash(context);
 
             // Assert: 黒番で空盤面なのでハッシュは 0
             Assert.AreEqual(0UL, hash, "空盤面の黒番ハッシュは 0 であるべきです");
 
             // 白番にすると TurnKey だけになる
             context.Turn = Disc.Color.White;
-            var hashWhite = ZobristHash.ComputeHash(context);
+            var hashWhite = _zobristHash.ComputeHash(context);
             Assert.AreEqual(ZobristKeys.TurnKey, hashWhite,
                 "空盤面の白番ハッシュは TurnKey であるべきです");
         }
@@ -119,9 +132,9 @@ namespace Reluca.Tests.Search.Transposition
             var context = CreateInitialPosition();
 
             // Act: 複数回計算
-            var hash1 = ZobristHash.ComputeHash(context);
-            var hash2 = ZobristHash.ComputeHash(context);
-            var hash3 = ZobristHash.ComputeHash(context);
+            var hash1 = _zobristHash.ComputeHash(context);
+            var hash2 = _zobristHash.ComputeHash(context);
+            var hash3 = _zobristHash.ComputeHash(context);
 
             // Assert: すべて同一
             Assert.AreEqual(hash1, hash2, "同一局面の複数回計算で異なるハッシュ");

--- a/Reluca/Di/DiProvider.cs
+++ b/Reluca/Di/DiProvider.cs
@@ -81,9 +81,10 @@ namespace Reluca.Di
             services.AddSingleton<EvalCacher, EvalCacher>();
             services.AddSingleton<ReverseResultCacher, ReverseResultCacher>();
 
-            // Transposition Table（Task 2 で追加、探索への統合は Task 3 以降）
+            // Transposition Table（Task 2 で追加）
             services.AddSingleton<TranspositionTableConfig, TranspositionTableConfig>();
             services.AddSingleton<ITranspositionTable, ZobristTranspositionTable>();
+            services.AddSingleton<IZobristHash, ZobristHash>();
 
             services.AddTransient<NegaMax, NegaMax>();
             services.AddTransient<CachedNegaMax, CachedNegaMax>();

--- a/Reluca/Search/SearchOptions.cs
+++ b/Reluca/Search/SearchOptions.cs
@@ -22,12 +22,19 @@ namespace Reluca.Search
         public int MaxDepth { get; }
 
         /// <summary>
+        /// Transposition Table を使用するかどうか
+        /// </summary>
+        public bool UseTranspositionTable { get; }
+
+        /// <summary>
         /// コンストラクタ
         /// </summary>
         /// <param name="maxDepth">最大探索深さ（省略時はデフォルト値）</param>
-        public SearchOptions(int maxDepth = DefaultMaxDepth)
+        /// <param name="useTranspositionTable">Transposition Table を使用するか（省略時は false）</param>
+        public SearchOptions(int maxDepth = DefaultMaxDepth, bool useTranspositionTable = false)
         {
             MaxDepth = maxDepth;
+            UseTranspositionTable = useTranspositionTable;
         }
     }
 }

--- a/Reluca/Search/Transposition/IZobristHash.cs
+++ b/Reluca/Search/Transposition/IZobristHash.cs
@@ -1,0 +1,29 @@
+/// <summary>
+/// 【ModuleDoc】
+/// 責務: Zobrist ハッシュ計算のインターフェースを定義する
+/// 入出力: GameContext → ulong ハッシュ値
+/// 副作用: なし
+///
+/// 備考:
+/// - Task 3c での差分更新実装を見据えたインターフェース抽出
+/// - 現状は ComputeHash のみ、将来的に UpdateHash を追加予定
+/// </summary>
+using Reluca.Contexts;
+
+namespace Reluca.Search.Transposition
+{
+    /// <summary>
+    /// Zobrist ハッシュ計算のインターフェースです。
+    /// 盤面状態から一意のハッシュ値を生成し、置換表のキーとして使用します。
+    /// </summary>
+    public interface IZobristHash
+    {
+        /// <summary>
+        /// 指定されたゲーム状態から Zobrist ハッシュ値を計算します。
+        /// 盤面上の全ての石と手番を考慮してハッシュ値を生成します。
+        /// </summary>
+        /// <param name="context">ゲーム状態</param>
+        /// <returns>計算されたハッシュ値</returns>
+        ulong ComputeHash(GameContext context);
+    }
+}

--- a/Reluca/Search/Transposition/ZobristHash.cs
+++ b/Reluca/Search/Transposition/ZobristHash.cs
@@ -5,7 +5,7 @@
 /// 副作用: なし
 ///
 /// 備考:
-/// - Task 2 では差分更新（UpdateHash）は未実装（将来の最適化として検討）
+/// - Task 3c での差分更新実装を見据え、インスタンスクラスに変更
 /// - 現状は ComputeHash でフルスキャン計算のみを提供
 /// </summary>
 using Reluca.Contexts;
@@ -17,7 +17,7 @@ namespace Reluca.Search.Transposition
     /// Zobrist ハッシュを計算するクラスです。
     /// 盤面状態と手番から一意のハッシュ値を生成し、置換表のキーとして使用します。
     /// </summary>
-    public static class ZobristHash
+    public class ZobristHash : IZobristHash
     {
         /// <summary>
         /// 盤面のマス数（8×8）。
@@ -30,7 +30,7 @@ namespace Reluca.Search.Transposition
         /// </summary>
         /// <param name="context">ゲーム状態</param>
         /// <returns>計算されたハッシュ値</returns>
-        public static ulong ComputeHash(GameContext context)
+        public ulong ComputeHash(GameContext context)
         {
             ulong hash = 0;
 


### PR DESCRIPTION
PvsSearchEngine に TT を統合し、探索の高速化を実現。

主な変更:
- IZobristHash インターフェース導入（Task 3c 差分更新に備え）
- ZobristHash を static から instance class へ変更
- SearchOptions に UseTranspositionTable フラグ追加
- PvsSearchEngine: コンストラクタ DI + TT Probe/Store/Move Ordering
- TT ON/OFF で同一結果を保証（テストで確認済み）