### PR TITLE
fix: Cacher の NullReferenceException を修正

### DIFF
--- a/Reluca/Cachers/MobilityCacher.cs
+++ b/Reluca/Cachers/MobilityCacher.cs
@@ -1,15 +1,20 @@
-﻿using Reluca.Contexts;
+/// <summary>
+/// 【ModuleDoc】
+/// 責務: 着手可能情報のキャッシュ機能を提供する
+/// 入出力: GameContext → IEnumerable&lt;int&gt;（キャッシュされた合法手リスト）
+/// 副作用: Add/Dispose で内部キャッシュを更新
+///
+/// 設計方針:
+/// - Cache の各要素は絶対に null にしない（NullReferenceException 防止）
+/// - コンストラクタで全スロット（0〜Stage.Max）を初期化
+/// - Dispose では Clear() のみ実行（null 代入禁止）
+/// </summary>
+using Reluca.Contexts;
 using Reluca.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Reluca.Cachers
 {
 #pragma warning disable CS8601
-#pragma warning disable CS8602
 
     /// <summary>
     /// 着手可能情報のキャッシュ機能を提供します。
@@ -17,17 +22,18 @@ namespace Reluca.Cachers
     public class MobilityCacher : ICacheable<GameContext, IEnumerable<int>>
     {
         /// <summary>
-        /// キャッシュ
+        /// キャッシュ（各要素は絶対に null にならない）
         /// </summary>
-        private Dictionary<int, Dictionary<string, IEnumerable<int>>?> Cache {  get; set; }
+        private Dictionary<int, Dictionary<string, IEnumerable<int>>> Cache { get; set; }
 
         /// <summary>
-        /// コンストラクタ
+        /// コンストラクタ。全スロットを初期化します。
         /// </summary>
         public MobilityCacher()
         {
-            Cache = new Dictionary<int, Dictionary<string, IEnumerable<int>>?>();
-            for (var i = 1; i <= Stage.Max; i++)
+            Cache = new Dictionary<int, Dictionary<string, IEnumerable<int>>>();
+            // 0 から Stage.Max まで全スロットを初期化（null になることを防止）
+            for (var i = 0; i <= Stage.Max; i++)
             {
                 Cache[i] = new Dictionary<string, IEnumerable<int>>();
             }
@@ -36,30 +42,31 @@ namespace Reluca.Cachers
         /// <summary>
         /// キャッシュを追加します。
         /// </summary>
-        /// <param name="key">キー</param>
-        /// <param name="value">値</param>
+        /// <param name="context">ゲーム状態</param>
+        /// <param name="value">合法手リスト</param>
         public void Add(GameContext context, IEnumerable<int> value)
         {
             Cache[context.Stage][GenerateKey(context)] = value;
         }
 
         /// <summary>
-        /// キャッシュを消去します。
+        /// 指定ステージより前のキャッシュをクリアします。
+        /// null 代入ではなく Clear() を使用します。
         /// </summary>
-        /// <param name="key">キー</param>
+        /// <param name="context">ゲーム状態</param>
         public void Dispose(GameContext context)
         {
             for (var i = 0; i < context.Stage; i++)
             {
-                Cache[i] = null;
+                Cache[i].Clear();
             }
         }
 
         /// <summary>
         /// キャッシュを取得します。
         /// </summary>
-        /// <param name="key">キー</param>
-        /// <returns>値</returns>
+        /// <param name="context">ゲーム状態</param>
+        /// <returns>合法手リスト</returns>
         public IEnumerable<int> Get(GameContext context)
         {
             return Cache[context.Stage][GenerateKey(context)];
@@ -68,8 +75,8 @@ namespace Reluca.Cachers
         /// <summary>
         /// キャッシュを取得するとともに、取得できたかどうかの結果を返却します。
         /// </summary>
-        /// <param name="key">キー</param>
-        /// <param name="value">値</param>
+        /// <param name="context">ゲーム状態</param>
+        /// <param name="value">合法手リスト</param>
         /// <returns>キャッシュが取得できたかどうか</returns>
         public bool TryGet(GameContext context, out IEnumerable<int> value)
         {
@@ -79,8 +86,8 @@ namespace Reluca.Cachers
         /// <summary>
         /// キーを生成します。
         /// </summary>
-        /// <param name="context"></param>
-        /// <returns></returns>
+        /// <param name="context">ゲーム状態</param>
+        /// <returns>キー文字列</returns>
         private static string GenerateKey(GameContext context)
         {
             return $"{context.Turn}|{context.Black}|{context.White}";

--- a/Reluca/Cachers/ReverseResultCacher.cs
+++ b/Reluca/Cachers/ReverseResultCacher.cs
@@ -1,33 +1,40 @@
-﻿using Reluca.Accessors;
+/// <summary>
+/// 【ModuleDoc】
+/// 責務: 裏返し結果のキャッシュ機能を提供する
+/// 入出力: GameContext → BoardContext（キャッシュされた盤面状態）
+/// 副作用: Add/Dispose で内部キャッシュを更新
+///
+/// 設計方針:
+/// - Cache の各要素は絶対に null にしない（NullReferenceException 防止）
+/// - コンストラクタで全スロット（0〜Stage.Max）を初期化
+/// - Dispose では Clear() のみ実行（null 代入禁止）
+/// </summary>
+using Reluca.Accessors;
 using Reluca.Contexts;
 using Reluca.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Reluca.Cachers
 {
 #pragma warning disable CS8601
-#pragma warning disable CS8602
+
     /// <summary>
     /// 裏返し結果のキャッシュ機能を提供します。
     /// </summary>
     public class ReverseResultCacher : ICacheable<GameContext, BoardContext>
     {
         /// <summary>
-        /// キャッシュ
+        /// キャッシュ（各要素は絶対に null にならない）
         /// </summary>
-        private Dictionary<int, Dictionary<string, BoardContext>?> Cache { get; set; }
+        private Dictionary<int, Dictionary<string, BoardContext>> Cache { get; set; }
 
         /// <summary>
-        /// コンストラクタ
+        /// コンストラクタ。全スロットを初期化します。
         /// </summary>
         public ReverseResultCacher()
         {
-            Cache = new Dictionary<int, Dictionary<string, BoardContext>?>();
-            for (var i = 1; i <= Stage.Max; i++)
+            Cache = new Dictionary<int, Dictionary<string, BoardContext>>();
+            // 0 から Stage.Max まで全スロットを初期化（null になることを防止）
+            for (var i = 0; i <= Stage.Max; i++)
             {
                 Cache[i] = new Dictionary<string, BoardContext>();
             }
@@ -36,8 +43,8 @@ namespace Reluca.Cachers
         /// <summary>
         /// キャッシュを追加します。
         /// </summary>
-        /// <param name="key">キー</param>
-        /// <param name="value">値</param>
+        /// <param name="context">ゲーム状態</param>
+        /// <param name="value">盤面状態</param>
         public void Add(GameContext context, BoardContext value)
         {
             Cache[context.Stage][GenerateKey(context)] = value;
@@ -47,30 +54,31 @@ namespace Reluca.Cachers
         /// キャッシュを追加します。
         /// </summary>
         /// <param name="move">指し手</param>
-        /// <param name="context">コンテクスト</param>
-        /// <param name="value">値</param>
+        /// <param name="context">ゲーム状態</param>
+        /// <param name="value">盤面状態</param>
         public void Add(int move, GameContext context, BoardContext value)
         {
             Cache[context.Stage][GenerateKey(move, context)] = BoardAccessor.DeepCopy(value);
         }
 
         /// <summary>
-        /// キャッシュを消去します。
+        /// 指定ステージより前のキャッシュをクリアします。
+        /// null 代入ではなく Clear() を使用します。
         /// </summary>
-        /// <param name="key">キー</param>
+        /// <param name="context">ゲーム状態</param>
         public void Dispose(GameContext context)
         {
             for (var i = 0; i < context.Stage; i++)
             {
-                Cache[i] = null;
+                Cache[i].Clear();
             }
         }
 
         /// <summary>
         /// キャッシュを取得します。
         /// </summary>
-        /// <param name="key">キー</param>
-        /// <returns>値</returns>
+        /// <param name="context">ゲーム状態</param>
+        /// <returns>盤面状態</returns>
         public BoardContext Get(GameContext context)
         {
             return Cache[context.Stage][GenerateKey(context)];
@@ -79,8 +87,8 @@ namespace Reluca.Cachers
         /// <summary>
         /// キャッシュを取得するとともに、取得できたかどうかの結果を返却します。
         /// </summary>
-        /// <param name="key">キー</param>
-        /// <param name="value">値</param>
+        /// <param name="context">ゲーム状態</param>
+        /// <param name="value">盤面状態</param>
         /// <returns>キャッシュが取得できたかどうか</returns>
         public bool TryGet(GameContext context, out BoardContext value)
         {
@@ -91,7 +99,7 @@ namespace Reluca.Cachers
         /// キーを生成します。
         /// </summary>
         /// <param name="context">ゲーム状態</param>
-        /// <returns>キー</returns>
+        /// <returns>キー文字列</returns>
         private static string GenerateKey(GameContext context)
         {
             return $"{context.Move}|{context.Black}|{context.White}";
@@ -102,7 +110,7 @@ namespace Reluca.Cachers
         /// </summary>
         /// <param name="move">指し手</param>
         /// <param name="context">ゲーム状態</param>
-        /// <returns>キー</returns>
+        /// <returns>キー文字列</returns>
         private static string GenerateKey(int move, GameContext context)
         {
             return $"{move}|{context.Black}|{context.White}";


### PR DESCRIPTION
- Cache[i] = null → Cache[i].Clear() に変更
- コンストラクタで 0〜Stage.Max まで全スロットを初期化
- Cache 型を非 nullable に変更し、null 代入を根本的に禁止
- ModuleDoc で設計方針（null 禁止ポリシー）を明記

対象ファイル:
- MobilityCacher.cs
- EvalCacher.cs
- ReverseResultCacher.cs

原因: VS の並列テスト実行時、Dispose() が Cache[i] を
null にすることで他テストの TryGet() が NullReferenceException